### PR TITLE
Enhance MetaMask Integration with Updated wallet_watchAsset Implementation

### DIFF
--- a/src/eip1193.rs
+++ b/src/eip1193.rs
@@ -138,11 +138,11 @@ extern "C" {
 
 impl Ethereum {
     pub fn default() -> Result<Self, Eip1193Error> {
-        return if let Ok(Some(eth)) = get_provider_js() {
+        if let Ok(Some(eth)) = get_provider_js() {
             Ok(eth)
         } else {
             Err(Eip1193Error::JsNoEthereum)
-        };
+        }
     }
 }
 

--- a/src/explorer.rs
+++ b/src/explorer.rs
@@ -41,17 +41,17 @@ impl TryInto<WalletDescription> for &WalletData {
     type Error = ExplorerError;
 
     fn try_into(self) -> Result<WalletDescription, Self::Error> {
-        let chains = self
-            .chains
-            .iter()
-            .filter_map(|c| {
-                if c.starts_with("eip155:") {
-                    c[6..].parse::<u64>().ok()
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
+        let chains =
+            self.chains
+                .iter()
+                .filter_map(|c| {
+                    if c.starts_with("eip155:") {
+                        c[6..].parse::<u64>().ok()
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
         let mobile_schema = match &self.mobile {
             None => None,
             Some(l) => match &l.native {
@@ -85,11 +85,7 @@ impl TryInto<WalletDescription> for &WalletData {
 
         Ok(WalletDescription {
             id: self.id.clone(),
-            short_name: self
-                .metadata
-                .short_name
-                .clone()
-                .unwrap_or(self.name.clone()),
+            short_name: self.metadata.short_name.clone().unwrap_or(self.name.clone()),
             name: self.name.clone(),
             chains,
             image_id: self.image_id.clone(),


### PR DESCRIPTION
**Context**
This pull request addresses specific integration issues between our DApp and MetaMask regarding the `wallet_watchAsset` method. Despite being marked as experimental, this method is extensively used across various DApps, requiring improved flexibility and robustness in its implementation to handle diverse asset management scenarios.

**Requirements/docs**:
https://docs.metamask.io/wallet/reference/wallet_watchasset/
