### PR TITLE
Adding publish n build scripts 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,20 @@
+name: Build process for project
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,50 @@
+name: Publish process for ethers-web
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy'
+        required: true
+        default: '0.0.0'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check version
+        run: |
+          CURRENT_VERSION=$(sed -n -e 's/^version = "\(.*\)"/\1/p' Cargo.toml)
+          INPUT_VERSION=${{ github.event.inputs.version }}
+          if [[ ! $INPUT_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Input version is not in the correct format (0-9.0-9.0-9)"
+            exit 1
+          fi
+          if [[ $(printf '%s\n' "$INPUT_VERSION" "$CURRENT_VERSION" | sort --version-sort | head -n1) == "$INPUT_VERSION" ]]; then
+            echo "Input version is not greater than the current version"
+            exit 1
+          fi
+
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
+      - name: Update version in toml
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/version/}
+          sed -i "s/^version = .*/version = \"${{ github.event.inputs.version }}\"/" Cargo.toml
+      - name: Commit and tag
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag version/${{ github.event.inputs.version }}
+          git push origin --tags
+
+      - name: Login to crates.io
+        run: echo "test" | cargo login
+      - name: Publish
+        run: cargo publish --verbose

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -45,6 +45,6 @@ jobs:
           git push origin --tags
 
       - name: Login to crates.io
-        run: echo "test" | cargo login
+        run: echo "${{ secrets.CARGO_TOKEN }}" | cargo login
       - name: Publish
         run: cargo publish --verbose


### PR DESCRIPTION
### Content changes
This PR introduces publishing and building process to our solution.

### Changes
- version checking logic in publish.yaml. Input version should be greater than the current version. If the input version is less than or equal to the current version, the workflow will fail. 
- create a git tag. The tag is created based on the input version and is pushed to the remote repository.  

PR is not ready, after acceptance I add SECRETS to process correctly push to **crates.io**